### PR TITLE
[FS-123885]: Power select scroll bug fix

### DIFF
--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -838,7 +838,7 @@ export default Component.extend({
     if(this.get('publicAPI.isOpen')) {
       run.later(() => {
         let option = this.get('publicAPI.options')[0];
-        if(this.get('publicAPI.highlighted') !== option) {
+        if(this.get('publicAPI.highlighted') !== option && this.get('publicAPI.isOpen')) {
           this.updateState({ highlighted: option });
         }
         this._setActiveDescendant(option);


### PR DESCRIPTION
[FS-123885](https://freshworks.freshrelease.com/ws/FS/tasks/FS-123885)

Description :
The selected option in the Power Select dropdown is not automatically scrolled into view when the dropdown is opened.